### PR TITLE
Fix arguments so they are not all sent as a giant string

### DIFF
--- a/contents/run-script
+++ b/contents/run-script
@@ -10,5 +10,5 @@ cat > "$SCRIPT" <<< "$RD_CONFIG_SCRIPT"
 # Make the script executable
 chmod +x "$SCRIPT"
 # Execute the script with arguments
-exec "$SCRIPT" "${RD_CONFIG_ARGUMENTS:-}"
+exec "$SCRIPT" ${RD_CONFIG_ARGUMENTS:-}
 # Done


### PR DESCRIPTION
All the arguments are passed through as one large string, I removed the quotes so the arguments are now properly separated out.